### PR TITLE
fix: answer capture — switch to Bukkit AsyncPlayerChatEvent

### DIFF
--- a/src/main/kotlin/net/badgersmc/trivia/application/TriviaService.kt
+++ b/src/main/kotlin/net/badgersmc/trivia/application/TriviaService.kt
@@ -45,8 +45,12 @@ class TriviaService(
 
     fun isGameActive(): Boolean = gameActive
 
-    /** Check if player already answered this round. Thread-safe early-out for the listener. */
-    fun hasPlayerAnswered(uuid: UUID): Boolean = answeredPlayers.contains(uuid)
+    /**
+     * Atomically claims the answer slot for this player.
+     * Returns true if the player hadn't answered yet, false if already claimed.
+     * Thread-safe — callable from any thread.
+     */
+    fun tryClaimAnswer(uuid: UUID): Boolean = answeredPlayers.add(uuid)
 
     /** Update config at runtime (for reload). */
     fun updateConfig(newConfig: TriviaConfig) {
@@ -97,15 +101,10 @@ class TriviaService(
         return true
     }
 
-    /** Process a player's answer. Must be called on the main thread. */
+    /** Process a player's answer. Caller must first claim via [tryClaimAnswer]. */
     fun checkAnswer(player: Player, answer: String): AnswerResult {
         if (!gameActive) return AnswerResult.NO_GAME
         val question = currentQuestionData ?: return AnswerResult.NO_GAME
-
-        if (answeredPlayers.contains(player.uniqueId)) {
-            return AnswerResult.ALREADY_ANSWERED
-        }
-        answeredPlayers.add(player.uniqueId)
 
         if (question.isCorrectAnswer(answer)) {
             endGame()

--- a/src/main/kotlin/net/badgersmc/trivia/application/TriviaService.kt
+++ b/src/main/kotlin/net/badgersmc/trivia/application/TriviaService.kt
@@ -38,12 +38,15 @@ class TriviaService(
     private var gameTaskId: Int = -1
     private var cooldownUntil: Long = 0L
     private var currentQuestionData: Question? = null
-    private val answeredPlayers: MutableSet<UUID> = HashSet()
+    private val answeredPlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
     val currentQuestion: Question? get() = currentQuestionData
     val isActive: Boolean get() = gameActive
 
     fun isGameActive(): Boolean = gameActive
+
+    /** Check if player already answered this round. Thread-safe early-out for the listener. */
+    fun hasPlayerAnswered(uuid: UUID): Boolean = answeredPlayers.contains(uuid)
 
     /** Update config at runtime (for reload). */
     fun updateConfig(newConfig: TriviaConfig) {

--- a/src/main/kotlin/net/badgersmc/trivia/infrastructure/bukkit/ChatListener.kt
+++ b/src/main/kotlin/net/badgersmc/trivia/infrastructure/bukkit/ChatListener.kt
@@ -1,19 +1,19 @@
 package net.badgersmc.trivia.infrastructure.bukkit
 
-import io.papermc.paper.event.player.AsyncChatEvent
 import net.badgersmc.nexus.i18n.LangService
 import net.badgersmc.trivia.application.ChatPlatform
 import net.badgersmc.trivia.application.TriviaService
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.bukkit.event.player.AsyncPlayerChatEvent
 
 /**
  * Single listener for mute enforcement and answer parsing (REQ-019).
- * Delegates mute control and channel validation to [ChatPlatform].
+ * Uses Bukkit's AsyncPlayerChatEvent (not Paper's AsyncChatEvent) to avoid
+ * Component-type mismatches and priority conflicts with RoseChat.
  *
- * On vanilla Paper: cancels AsyncChatEvent at LOWEST priority.
+ * On vanilla Paper: cancels AsyncPlayerChatEvent at LOWEST priority.
  * On RoseChat: mute only enforced for the trivia channel; other channels are untouched.
  */
 class ChatListener(
@@ -22,17 +22,14 @@ class ChatListener(
     private val chatPlatform: ChatPlatform,
 ) : Listener {
 
-    private val plain = PlainTextComponentSerializer.plainText()
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    fun onChat(event: AsyncChatEvent) {
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = false)
+    fun onChat(event: AsyncPlayerChatEvent) {
         val player = event.player
 
         // Only active during a game
         if (!triviaService.isActive) return
 
-        // Extract plain text from any Component type (TextComponent, TranslatableComponent, etc.)
-        val content = plain.serialize(event.message()).trim()
+        val content = event.message.trim()
         if (content.isEmpty()) return
 
         // Channel/platform check first — only trivia-channel messages proceed
@@ -58,6 +55,13 @@ class ChatListener(
 
         if (isValidAnswer) {
             event.isCancelled = true
+
+            // Early-out: block duplicate answers before scheduling
+            if (triviaService.hasPlayerAnswered(player.uniqueId)) {
+                player.sendMessage(lang.msg("game.already_answered"))
+                return
+            }
+
             val mapped = when {
                 normalized.startsWith("t") -> "true"
                 normalized.startsWith("f") -> "false"

--- a/src/main/kotlin/net/badgersmc/trivia/infrastructure/bukkit/ChatListener.kt
+++ b/src/main/kotlin/net/badgersmc/trivia/infrastructure/bukkit/ChatListener.kt
@@ -56,8 +56,8 @@ class ChatListener(
         if (isValidAnswer) {
             event.isCancelled = true
 
-            // Early-out: block duplicate answers before scheduling
-            if (triviaService.hasPlayerAnswered(player.uniqueId)) {
+            // Atomic claim — blocks duplicates before scheduling
+            if (!triviaService.tryClaimAnswer(player.uniqueId)) {
                 player.sendMessage(lang.msg("game.already_answered"))
                 return
             }

--- a/src/test/kotlin/net/badgersmc/trivia/application/TriviaServiceTest.kt
+++ b/src/test/kotlin/net/badgersmc/trivia/application/TriviaServiceTest.kt
@@ -97,6 +97,7 @@ class TriviaServiceTest {
         service.startGame()
 
         val player = mockPlayer()
+        service.tryClaimAnswer(player.uniqueId)
         service.checkAnswer(player, question.correctAnswerLetter.lowercase())
 
         val second = service.startGame()
@@ -112,6 +113,7 @@ class TriviaServiceTest {
 
         val correctLetter = question.correctAnswerLetter.lowercase()
         val player = mockPlayer()
+        service.tryClaimAnswer(player.uniqueId)
         val result = service.checkAnswer(player, correctLetter)
 
         assertEquals(TriviaService.AnswerResult.CORRECT, result)
@@ -127,6 +129,7 @@ class TriviaServiceTest {
         service.startGame()
 
         val player = mockPlayer()
+        service.tryClaimAnswer(player.uniqueId)
         val result = service.checkAnswer(player, wrongLetter(question))
 
         assertEquals(TriviaService.AnswerResult.WRONG, result)
@@ -135,17 +138,18 @@ class TriviaServiceTest {
     }
 
     @Test
-    fun `already answered player is rejected`() {
+    fun `already answered player is rejected by tryClaimAnswer`() {
         val question = createQuestion("Paris")
         every { fetcher.isEmpty } returns false
         every { fetcher.poll() } returns question
         service.startGame()
 
         val player = mockPlayer()
+        assertTrue(service.tryClaimAnswer(player.uniqueId))
         service.checkAnswer(player, wrongLetter(question))
-        val second = service.checkAnswer(player, wrongLetter(question))
 
-        assertEquals(TriviaService.AnswerResult.ALREADY_ANSWERED, second)
+        val claimed = service.tryClaimAnswer(player.uniqueId)
+        assertFalse(claimed)
     }
 
     @Test
@@ -169,6 +173,7 @@ class TriviaServiceTest {
         val player = mockPlayer()
         every { player.hasPermission("lumatrivia.mute.bypass") } returns true
 
+        service.tryClaimAnswer(player.uniqueId)
         val result = service.checkAnswer(player, wrongLetter(question))
         assertEquals(TriviaService.AnswerResult.WRONG, result)
         verify(exactly = 0) { chat.mutePlayer(any(), any()) }


### PR DESCRIPTION
## Root cause
RoseChat cancels `AsyncPlayerChatEvent` at its configured priority (HIGHEST/LOW). Paper's `AsyncChatEvent` either doesn't fire or fires cancelled when the legacy event is cancelled.

## Fix
Switch from Paper's `AsyncChatEvent` (Component-based) to Bukkit's `AsyncPlayerChatEvent` (String-based `.getMessage()`).

## Also included
- **`ignoreCancelled = false`** — fires even if other plugins cancelled
- **Thread-safe `answeredPlayers`** — `ConcurrentHashMap.newKeySet()` for async reads
- **Early duplicate check** — blocks repeat answers before scheduler dispatch
- **Answer format hints** — "Type a–d" / "Type true/false" on invalid input
- **Admin mute guard** — RoseChatPlatform never overwrites/strips pre-existing mutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Breaking
- TriviaService: Require callers to claim answers via `tryClaimAnswer` before calling `checkAnswer` to avoid duplicate-answer handling races.

Fixes
- ChatListener: Capture trivia answers from Bukkit `AsyncPlayerChatEvent` (including cancelled events via `ignoreCancelled = false`) using `event.message`.
- ChatListener: Atomically reject duplicate answers before scheduling correctness checks.
- TriviaService: Claim answers with an atomic `tryClaimAnswer(UUID): Boolean` to prevent duplicate-answer TOCTOU races.
- RoseChatPlatform: Preserve existing admin mutes instead of overwriting or removing them.
- Trivia answers: Add format hints for invalid answers.

Features
- TriviaService: Track answered players with a thread-safe `answeredPlayers` set and expose public `tryClaimAnswer` for duplicate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->